### PR TITLE
Add rook-ceph

### DIFF
--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rook-ceph/ks.yaml
+components:
+  - ../../flux/components/namespace
+patches:
+  - # Add the name to the namespace
+    patch: |
+      - op: add
+        path: /metadata/name
+        value: rook-ceph
+    target:
+      kind: Namespace

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.17.6
+  url: oci://ghcr.io/rook/rook-ceph
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-operator
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+values:
+  csi:
+    cephFSKernelMountOptions: ms_mode=prefer-crc
+    enableCephfsDriver: false
+    enableCephfsSnapshotter: false
+    enableLiveness: true
+    serviceMonitor:
+      enabled: true
+    csiRBDProvisionerResource: |
+      - name : csi-provisioner
+        resource:
+          requests:
+            memory: 16Mi
+            cpu: 5m
+          limits:
+            memory: 32Mi
+            cpu: 100m
+      - name : csi-resizer
+        resource:
+          requests:
+            memory: 48Mi
+            cpu: 5m
+          limits:
+            memory: 96Mi
+            cpu: 100m
+      - name : csi-attacher
+        resource:
+          requests:
+            memory: 32Mi
+            cpu: 5m
+          limits:
+            memory: 64Mi
+            cpu: 100m
+      - name : csi-snapshotter
+        resource:
+          requests:
+            memory: 16Mi
+            cpu: 5m
+          limits:
+            memory: 32Mi
+            cpu: 100m
+      - name : csi-rbdplugin
+        resource:
+          requests:
+            memory: 48Mi
+            cpu: 15m
+          limits:
+            memory: 96Mi
+            cpu: 200m
+      - name : liveness-prometheus
+        resource:
+          requests:
+            memory: 24Mi
+            cpu: 5m
+          limits:
+            memory: 48Mi
+            cpu: 100m
+    csiRBDPluginResource: |
+      - name : driver-registrar
+        resource:
+          requests:
+            memory: 64Mi
+            cpu: 5m
+          limits:
+            memory: 128Mi
+            cpu: 100m
+      - name : csi-rbdplugin
+        resource:
+          requests:
+            memory: 64Mi
+            cpu: 10m
+          limits:
+            memory: 192Mi
+            cpu: 200m
+      - name : liveness-prometheus
+        resource:
+          requests:
+            memory: 48i
+            cpu: 5m
+          limits:
+            memory: 96Mi
+            cpu: 100m
+  cephCommandsTimeoutSeconds: "20"
+  monitoring:
+    enabled: true
+    createPrometheusRules: true
+  resources:
+    requests:
+      memory: 128Mi # unchangable
+      cpu: 100m # unchangable
+    limits: {}

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/secret.sops.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rook-ceph-dashboard-password
+type: Opaque
+stringData:
+  password: ENC[AES256_GCM,data:oKJHXfcXsOS0hQgHBcgNp4jj92DCNg==,iv:Wo5TM4vHTBQhgfqJ5HQ0mMRj/bYhIx6PPza3iYagGYE=,tag:1DLMHo2RFcle7oiyf/PVyw==,type:str]
+sops:
+  age:
+    - recipient: age1th0ayw6msyjqrehtp00pp0tj20l70vr4jn7jsuga8katkg69xd7snevqy4
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5cFIySmJuSVlzZjlTYTJP
+        YUEzSkZoTmdmVUpMbHJsUGJOaXZUSmN1NFJRCm5wakdGSlBPWXdubXlDNkt6K0VD
+        bnYrU0gzeEo2VUtVMVNuS2ZENGczbXcKLS0tIFRxMlBIWmNKaE1VUTUyRnF6N0dz
+        SXM0Ynhia2ZsWmcwa0l5RTNnbFlhcEUK+2JSwZudF+Zvh3lowoj7q6mvUmOynO01
+        V7VYtBJO5GQZhd9OubesXaTdqAsWngJGVSSIGIRno7YvDAohL9GecQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-07-13T10:05:53Z"
+  mac: ENC[AES256_GCM,data:8reKNnhNuDzNhaL4dDTBcrynA4yDY5QtaR0BJEX3jsKrbO1UzgjWmbXF13YHYa5YUczRUdrEo4qFQRKgnbs+dQRL2FD0eJyOhPyPhI/UV6t2x8ttyxvb9sxGoOHd1z6ODScNLedr2ttIBNr9NtFdbs81uPpd5yNGlVMa2f3sofk=,iv:p2mtoK1TcV7+UVFLZjDHHgs8xMqdd0/VBF3Z/SwKDbM=,tag:RkMfs+EieNiUPCU1kxYjEA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -1,0 +1,171 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.17.6
+  url: oci://ghcr.io/rook/rook-ceph-cluster
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph-cluster
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+    toolbox:
+      enabled: true
+    cephClusterSpec:
+      cephConfig:
+        global:
+          bdev_enable_discard: "true" # quote
+          bdev_async_discard_threads: "1" # quote
+          osd_class_update_on_start: "false" # quote
+          device_failure_prediction_mode: local # requires mgr module
+      cleanupPolicy:
+        wipeDevicesFromOtherClusters: true
+      crashCollector:
+        disable: false
+      csi:
+        readAffinity:
+          enabled: true
+      dashboard:
+        enabled: true
+        urlPrefix: /
+        ssl: false
+        prometheusEndpoint: http://prometheus-operated.monitoring.svc.cluster.local:9090
+      mgr:
+        modules:
+          - name: diskprediction_local
+            enabled: true
+          - name: insights
+            enabled: true
+          - name: pg_autoscaler
+            enabled: true
+          - name: rook
+            enabled: true
+      network:
+        provider: host
+        connections:
+          requireMsgr2: true
+      storage:
+        useAllNodes: true
+        useAllDevices: false
+        devicePathFilter: "/dev/disk/by-id/(ata-SAMSUNG_MZ7KM*|ata-SAMSUNG_SSD_PM871b_*)" # (ata-SAMSUNG_MZ7KM1T9HAJM-00005_S2HNNX0HA00353|ata-SAMSUNG_SSD_PM871b_2.5_7mm_256GB_S3U4NX0K852590|ata-SAMSUNG_MZ7KM480HMHQ-00005_S3F4NX0JA06408)" # List these with: talosctl list /dev/disk/by-id
+        config:
+          osdsPerDevice: "1"
+      resources:
+        mgr:
+          limits:
+            cpu: 500m
+            memory: 700Mi
+          requests:
+            cpu: 50m
+            memory: 320Mi
+        mon:
+          limits:
+            cpu: 500m
+            memory: 640Mi
+          requests:
+            cpu: 100m
+            memory: 320Mi
+        osd:
+          limits:
+            cpu: 500m
+            memory: 1600Mi
+          requests:
+            cpu: 150m
+            memory: 800Mi
+        prepareosd:
+          limits:
+            cpu: 1000m
+            memory: 400Mi
+          requests:
+            cpu: 50m
+            memory: 200Mi
+        mgr-sidecar:
+          limits:
+            cpu: 256m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 40Mi
+        crashcollector:
+          limits:
+            cpu: 100m
+            memory: 64M
+          requests:
+            cpu: 15m
+            memory: 32M
+        logcollector:
+          limits:
+            cpu: 50m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        cleanup:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+    cephBlockPools:
+      - name: ceph-blockpool
+        spec:
+          failureDomain: host
+          replicated:
+            size: 2
+        storageClass:
+          enabled: true
+          name: ceph-block
+          isDefault: true
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          volumeBindingMode: Immediate
+          mountOptions: ["discard"]
+          parameters:
+            compression_mode: aggressive
+            compression_algorithm: zstd
+            imageFormat: "2"
+            imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/fstype: ext4
+    cephBlockPoolsVolumeSnapshotClass:
+      enabled: true
+      name: csi-ceph-blockpool
+      isDefault: false
+      deletionPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      mountOptions: ["discard"]
+    cephFileSystems: []
+    cephObjectStores: []

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app rook-ceph
   namespace: flux-system
 spec:
-  targetNamespace: &ns rook-ceph
+  targetNamespace: rook-ceph
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
@@ -26,13 +26,13 @@ metadata:
   name: &app rook-ceph-cluster
   namespace: flux-system
 spec:
-  targetNamespace: *ns
+  targetNamespace: rook-ceph
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: rook-ceph
-      namespace: *ns
+      namespace: rook-ceph
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   prune: true
   sourceRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -30,6 +30,9 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph
+      namespace: *ns
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   prune: true
   sourceRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -6,11 +6,31 @@ metadata:
   name: &app rook-ceph
   namespace: flux-system
 spec:
-  targetNamespace: rook-ceph
+  targetNamespace: &ns rook-ceph
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   path: ./kubernetes/apps/rook-ceph/rook-ceph/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-cluster
+  namespace: flux-system
+spec:
+  targetNamespace: *ns
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
This is a combination of [chkpwd's rook-ceph deployment](https://github.com/chkpwd/iac/tree/cee160e7c51821d3638bb8e114134ac978861e90/kubernetes/core/rook-ceph) and [onedr0p's](https://github.com/onedr0p/home-ops/tree/70f8fae146e4ca439f8938802017a3d5194ef229/kubernetes/apps/rook-ceph), amended with my own filter for my Ceph disks.